### PR TITLE
Fix version parsing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,10 +27,7 @@ fn get_package_version(package_name: &str) -> Option<String> {
 
 /// Parse the output of `uname -r`
 fn parse_uname_output(uname_output: &str) -> Option<String> {
-    uname_output
-        .split("-ARCH")
-        .next()
-        .map(|normalized| normalized.replace("-arch", ".arch"))
+    Some(uname_output.trim().replace("-arch", "."))
 }
 
 /// Parse the output of `xdpyinfo`

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,30 +118,14 @@ mod test {
 
     #[test]
     fn test_parse_pacman_output() {
-        assert_eq!(Some("4.5.4-1"), parse_pacman_output("linux 4.5.4-1"));
-    }
-
-    #[test]
-    fn test_parse_new_pacman_output() {
-        assert_eq!(
-            Some("4.18.3.arch1-1"),
-            parse_pacman_output("linux 4.18.3.arch1-1")
-        );
-    }
-
-    #[test]
-    fn test_parse_new_uname_output() {
-        assert_eq!(
-            Some("4.18.3.arch1-1".to_owned()),
-            parse_uname_output("4.18.3-arch1-1-ARCH")
-        );
+        assert_eq!(Some("5.3.11.1-1"), parse_pacman_output("linux 5.3.11.1-1"));
     }
 
     #[test]
     fn test_parse_uname_output() {
         assert_eq!(
-            Some("4.5.4-1".to_owned()),
-            parse_uname_output("4.5.4-1-ARCH")
+            Some("5.3.11.1-1".to_owned()),
+            parse_uname_output("5.3.11-arch1-1")
         );
     }
 


### PR DESCRIPTION
Apparently `uname` and `pacman` provided linux version output changed again.