### PR TITLE
Use libalpm directly to query database btw.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
 
   test:
     docker:
-      - image: rust:1.32
+      - image: archlinux
     steps:
       - checkout
       - restore_cache:
@@ -11,11 +11,11 @@ jobs:
             - v1-cargo-cache-{{ arch }}-{{ .Branch }}
             - v1-cargo-cache-{{ arch }}
       - run:
-          name: Install dependencies
-          command: apt-get update && apt-get install -y libdbus-glib-1-dev
+          name: Install rustup and dbus
+          command: pacman --noconfirm -Sy rustup dbus gcc pkg-config
       - run:
-          name: Show versions
-          command: rustc --version && cargo --version
+          name: Install rustc
+          command: rustup install 1.32.0
       - run:
           name: Build
           command: cargo build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "alpm"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "alpm-sys-fork 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "alpm-sys-fork"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arrayref"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +340,7 @@ dependencies = [
 name = "reboot-arch-btw"
 version = "0.1.3"
 dependencies = [
+ "alpm 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify-rust 3.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -467,6 +482,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+"checksum alpm 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bb74d01ed86932b1f061d32715faec77104239140557cc6e4f7ce5da9bcfafd"
+"checksum alpm-sys-fork 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec7b55dfea0a6b63c8c465d15650ea50be7a85d70d22d95b8798e71114c40310"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ include = [
 ]
 
 [dependencies]
-notify-rust = "3.0"
+alpm = "0.9"
 docopt = "1.1"
+notify-rust = "3.0"
 serde = "1.0"
 serde_derive = "1.0"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ This is a small utility which shows the installed and running Linux kernel on
 the kernel got updated and suddenly your USB drive won't mount because the
 needed kernel module can't get loaded.
 
-To get the version of the installed kernel it uses `pacman -Q linux` and to get
-the version of the running kernel it uses `uname -r`.
+To get the version of the installed kernel it uses libalpm (shipped with
+pacman) to query the local pacman database. To get the version of the running
+kernel it uses `uname -r`.
 
 Install
 -------
@@ -34,9 +35,9 @@ Usage
 ```Shell
 $ reboot-arch-btw
 Kernel
- installed: 5.3.11.1-1
- running:   5.3.11.1-1
+ installed: 5.6.10-arch1-1 (since 3 days ago)
+ running:   5.6.10-arch1-1
 Xorg server
- installed: 1.20.5-4
- running:   1.20.5
+ installed: 1.20.8-2 (since 3 days ago)
+ running:   1.20.8
 ```


### PR DESCRIPTION
Get installed package version from alpm.

Additionally, don't remove "arch" from the kernel version. Instead, transform Arch package version format to kernel version format.

Structure has been refactored a bit by introducing the `PackageInfo` struct.

This replaces the alpm part of #14. The additional parsing fixes could be implemented inside `cleanup_pkg_version`.