### PR TITLE
Increase minimal required Rust version to 1.48.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
 
   test:
     docker:
-      - image: rnestler/archlinux-rust:1.42.0
+      - image: rnestler/archlinux-rust:1.48.0
     steps:
       - checkout
       - restore_cache:
@@ -24,7 +24,7 @@ jobs:
 
   lint:
     docker:
-      - image: rnestler/archlinux-rust:1.42.0
+      - image: rnestler/archlinux-rust:1.48.0
     steps:
       - checkout
       - restore_cache:
@@ -40,7 +40,7 @@ jobs:
 
   fmt:
     docker:
-      - image: rnestler/archlinux-rust:1.42.0
+      - image: rnestler/archlinux-rust:1.48.0
     steps:
       - checkout
       - run: rustup component add rustfmt
@@ -48,7 +48,7 @@ jobs:
 
   audit:
     docker:
-      - image: rnestler/archlinux-rust:1.42.0
+      - image: rnestler/archlinux-rust:1.48.0
     steps:
       - checkout
       - restore_cache:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You may just install it from the AUR:
 Build
 -----
 
-This project requires Rust 1.42.0 or newer. Also you need to have dbus
+This project requires Rust 1.48.0 or newer. Also you need to have dbus
 installed.
 
 ```Shell

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-use alpm;
-use docopt;
-use notify_rust;
 use serde_derive::Deserialize;
 
 use std::process::Command;


### PR DESCRIPTION
cargo-audit seems to require a newer Rust version.