### PR TITLE
Fix version comparison for kernel package with missing patch version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+ * Fix bug when the kernel patch version is 0
+   ([#8](https://github.com/rnestler/reboot-arch-btw/issues/8) and
+   [#60](https://github.com/rnestler/reboot-arch-btw/pull/60))
+
 ## [v0.3.2] - 2021-10-03
 
  * Update dependencies

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ impl PackageInfo {
 
     /// Read a decimal number from the input and return the parsed number and the remaining input
     fn read_number(input: &str) -> (Option<u32>, &str) {
-        let res = input.find(|ch| !(ch >= '0' && ch <= '9'));
+        let res = input.find(|ch| !('0'..='9').contains(&ch));
         if res.is_none() {}
         match res {
             None => (input.parse().ok(), ""),
@@ -30,11 +30,7 @@ impl PackageInfo {
 
     /// Read a `.` or not and return the remaining input
     fn read_dot(input: &str) -> &str {
-        if input.starts_with('.') {
-            &input[1..]
-        } else {
-            input
-        }
+        input.strip_prefix('.').unwrap_or(input)
     }
 
     /// Clean up Arch package versions.

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,17 +10,54 @@ struct PackageInfo {
 }
 
 impl PackageInfo {
-    fn from_package(pkg: &alpm::Package) -> Self {
-        Self {
-            version: Self::cleanup_pkg_version(pkg.version()),
+    fn from_package(pkg: &alpm::Package) -> Option<Self> {
+        Some(Self {
+            version: Self::cleanup_pkg_version(pkg.version())?,
             install_date: pkg.install_date(),
+        })
+    }
+
+    /// Read a decimal number from the input and return the parsed number and the remaining input
+    fn read_number(input: &str) -> (Option<u32>, &str) {
+        let res = input.find(|ch| !(ch >= '0' && ch <= '9'));
+        if res.is_none() {}
+        match res {
+            None => (input.parse().ok(), ""),
+            Some(0) => (None, input),
+            Some(x) => (input[0..x].parse().ok(), &input[x..]),
+        }
+    }
+
+    /// Read a `.` or not and return the remaining input
+    fn read_dot(input: &str) -> &str {
+        if input.starts_with('.') {
+            &input[1..]
+        } else {
+            input
         }
     }
 
     /// Clean up Arch package versions.
-    #[inline]
-    fn cleanup_pkg_version(raw_version: &str) -> String {
-        raw_version.replace("-", ".")
+    fn cleanup_pkg_version(raw_version: &str) -> Option<String> {
+        let mut version = String::new();
+        let (n, mut remaining) = Self::read_number(raw_version);
+        version += &n?.to_string();
+        remaining = Self::read_dot(remaining);
+        version += ".";
+
+        let (n, mut remaining) = Self::read_number(remaining);
+        version += &n?.to_string();
+        remaining = Self::read_dot(remaining);
+        version += ".";
+
+        // if third digit is missing insert a 0.
+        let (n, _) = Self::read_number(remaining);
+        if n.is_none() {
+            version += "0."
+        }
+        version += remaining;
+
+        Some(version.replace("-", "."))
     }
 
     /// Return a string representing the "time ago" when this package was
@@ -83,7 +120,7 @@ fn get_package_version(db: &alpm::Db, package_name: &str) -> Option<PackageInfo>
         Ok(pkg) => pkg,
         Err(_) => return None,
     };
-    Some(PackageInfo::from_package(&pkg))
+    PackageInfo::from_package(&pkg)
 }
 
 /// Parse the output of `xdpyinfo`
@@ -181,12 +218,35 @@ mod test {
     fn test_cleanup_pkg_version() {
         assert_eq!(
             PackageInfo::cleanup_pkg_version("5.3.11.1-1"),
-            "5.3.11.1.1".to_owned(),
+            Some("5.3.11.1.1".to_owned()),
         );
         assert_eq!(
             PackageInfo::cleanup_pkg_version("5.4.1.arch1-1"),
-            "5.4.1.arch1.1".to_owned(),
+            Some("5.4.1.arch1.1".to_owned()),
         );
+    }
+
+    #[test]
+    fn test_cleanup_pkg_version_missing_patch_digit() {
+        assert_eq!(
+            PackageInfo::cleanup_pkg_version("5.16.arch1-1"),
+            Some("5.16.0.arch1.1".to_owned()),
+        );
+    }
+
+    #[test]
+    fn test_read_number_none() {
+        assert_eq!((None, "foo"), PackageInfo::read_number("foo"));
+    }
+
+    #[test]
+    fn test_read_number_only_number() {
+        assert_eq!((Some(90), ""), PackageInfo::read_number("90"));
+    }
+
+    #[test]
+    fn test_read_number() {
+        assert_eq!((Some(1), ".1-foo"), PackageInfo::read_number("1.1-foo"));
     }
 
     #[test]


### PR DESCRIPTION
By parsing the kernel package version digit by digit we can check if the
third digit (the patch version) is missing and insert it. I tried to
avoid pulling in any dependencies like regex to do the fix.

Fixes #8