### PR TITLE
Remove cargo-audit ignores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: pacman --noconfirm -Sy cargo-audit
-      - run: cargo audit --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0159
+      - run: cargo audit


### PR DESCRIPTION
The advisories have been withdrawn since they don't seem to be security
critical and the problem goes all the way down to the POSIX API.

See https://github.com/rustsec/advisory-db/issues/1190