### PR TITLE
Bump Rust version to 1.63.0 for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   build_and_test:
     runs-on: ubuntu-20.04
-    container: rnestler/archlinux-rust:1.60.0
+    container: rnestler/archlinux-rust:1.63.0
     steps:
       - uses: actions/checkout@v2
       - run: cargo build
@@ -15,7 +15,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-20.04
-    container: rnestler/archlinux-rust:1.60.0
+    container: rnestler/archlinux-rust:1.63.0
     steps:
       - uses: actions/checkout@v2
       - run: rustup component add clippy
@@ -23,7 +23,7 @@ jobs:
 
   fmt:
     runs-on: ubuntu-20.04
-    container: rnestler/archlinux-rust:1.60.0
+    container: rnestler/archlinux-rust:1.63.0
     steps:
       - uses: actions/checkout@v2
       - run: rustup component add rustfmt
@@ -31,7 +31,7 @@ jobs:
 
   audit:
     runs-on: ubuntu-20.04
-    container: rnestler/archlinux-rust:1.60.0
+    container: rnestler/archlinux-rust:1.63.0
     steps:
       - uses: actions/checkout@v2
       - run: pacman --noconfirm -Sy cargo-audit

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cargo install reboot-arch-btw
 Build
 -----
 
-This project requires Rust 1.53.0 or newer. Also you need to have dbus
+This project requires Rust 1.63.0 or newer. Also you need to have dbus
 installed.
 
 ```Shell


### PR DESCRIPTION
Also mention in the README that Rust 1.63.0 is required. It may still
compile with an older version, but we don't guarantee it.