### PR TITLE
Distinguish between kernel and system package updates

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -3,6 +3,7 @@ pub enum CheckResult {
     Nothing,
     RestartSession,
     Reboot,
+    KernelUpdate,
 }
 
 impl CheckResult {
@@ -10,7 +11,7 @@ impl CheckResult {
         match self {
             CheckResult::Nothing => "All good",
             CheckResult::RestartSession => "Restart your session btw",
-            CheckResult::Reboot => "Reboot arch btw",
+            CheckResult::Reboot | CheckResult::KernelUpdate => "Reboot arch btw",
         }
     }
 
@@ -21,6 +22,7 @@ impl CheckResult {
                 "System packages got updated. You should logout to restart your session."
             }
             CheckResult::Reboot => "System packages got updated. You should reboot your system!",
+            CheckResult::KernelUpdate => "Kernel got updated. You should reboot your system!",
         }
     }
 }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -73,7 +73,7 @@ impl Check for KernelChecker {
         println!(" running:   {}", running_kernel_version);
         let should_reboot = running_kernel_version != &cleaned_kernel_version;
         if should_reboot {
-            CheckResult::Reboot
+            CheckResult::KernelUpdate
         } else {
             CheckResult::Nothing
         }
@@ -130,7 +130,7 @@ mod test {
             },
         };
 
-        assert_eq!(kernel_checker.check(), CheckResult::Reboot);
+        assert_eq!(kernel_checker.check(), CheckResult::KernelUpdate);
     }
 
     #[test]


### PR DESCRIPTION
There is more need to reboot if the kernel got updated compared to other system packages.