### PR TITLE
Update notify-rust to 4.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,16 +603,14 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.6.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc2e370356160e41aba3fd0fbac26d86a89ddd2ac4300c03de999a77cfa2509"
+checksum = "3ce656bb6d22a93ae276a23de52d1aec5ba4db3ece3c0eb79dfd5add7384db6a"
 dependencies = [
  "mac-notification-sys",
  "serde",
  "tauri-winrt-notification",
  "zbus",
- "zvariant",
- "zvariant_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2018"
 [dependencies]
 alpm = "2.1.0"
 clap = { version = "4.1.1", features = ["help", "usage", "error-context", "std", "derive"], default-features = false }
-notify-rust = "4.5"
+notify-rust = "4.7"
 utmp-rs = "0.3.0"
 time = "0.3.14"
 log = "0.4.17"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-use std::{num::ParseIntError, str::FromStr};
-
 use clap::Parser;
 use log::error;
 use notify_rust::{Notification, Timeout};
@@ -14,14 +12,6 @@ use checks::{Check, CheckResult};
 mod critical_packages_check;
 use critical_packages_check::CriticalPackagesCheck;
 mod session;
-
-fn timeout_from_str(s: &str) -> Result<Timeout, ParseIntError> {
-    match s {
-        "default" => Ok(Timeout::Default),
-        "never" => Ok(Timeout::Never),
-        milliseconds => Ok(Timeout::Milliseconds(u32::from_str(milliseconds)?)),
-    }
-}
 
 #[derive(Debug, Parser)]
 #[clap(
@@ -40,7 +30,7 @@ struct Args {
     /// * "never" or "0" will cause the notification never to expire.
     ///
     /// * Any other number will be interpreted as the timeout in milliseconds.
-    #[clap(long, value_parser(timeout_from_str), default_value = "default")]
+    #[clap(long, default_value = "default")]
     notification_timeout: Timeout,
 
     /// Comma separated list of packages were we should reboot after an upgrade.


### PR DESCRIPTION
This included the `FromStr` for `Timeout` implementation (https://github.com/hoodie/notify-rust/pull/169) so we can get rid of our custom implementation.