### PR TITLE
Use is_ascii_digit instead of manual range check

### DIFF
--- a/src/package.rs
+++ b/src/package.rs
@@ -16,7 +16,7 @@ impl PackageInfo {
 
     /// Read a decimal number from the input and return the parsed number and the remaining input
     pub fn read_number(input: &str) -> (Option<u32>, &str) {
-        let res = input.find(|ch| !('0'..='9').contains(&ch));
+        let res = input.find(|ch: char| !ch.is_ascii_digit());
         if res.is_none() {}
         match res {
             None => (input.parse().ok(), ""),


### PR DESCRIPTION
As reported by clippy:

    warning: manual check for common ascii range
      --> src/package.rs:19:36
       |
    19 |         let res = input.find(|ch| !('0'..='9').contains(&ch));
       |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `ch.is_ascii_digit()`
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_ascii_check
       = note: `#[warn(clippy::manual_is_ascii_check)]` on by default