### PR TITLE
Update to Rust 1.70 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   build_and_test:
     runs-on: ubuntu-22.04
-    container: rnestler/archlinux-rust:1.65.0
+    container: rnestler/archlinux-rust:1.70.0
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -27,7 +27,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-22.04
-    container: rnestler/archlinux-rust:1.65.0
+    container: rnestler/archlinux-rust:1.70.0
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -47,7 +47,7 @@ jobs:
 
   fmt:
     runs-on: ubuntu-22.04
-    container: rnestler/archlinux-rust:1.65.0
+    container: rnestler/archlinux-rust:1.70.0
     steps:
       - uses: actions/checkout@v3
       - run: rustup component add rustfmt

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cargo install reboot-arch-btw
 
 ## Build
 
-This project requires Rust 1.65.0 or newer. Also you need to have dbus
+This project requires Rust 1.70.0 or newer. Also you need to have dbus
 installed.
 
 ```Shell


### PR DESCRIPTION
We generally want the latest version with the latest lints, since Arch will always have the latest Rust version.