### PR TITLE
Update system before checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     container: rnestler/archlinux-rust:1.70.0
     steps:
+      - run: pacman -Syu --noconfirm
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
         with:
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     container: rnestler/archlinux-rust:1.70.0
     steps:
+      - run: pacman -Syu --noconfirm
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
         with:
@@ -49,6 +51,7 @@ jobs:
     runs-on: ubuntu-22.04
     container: rnestler/archlinux-rust:1.70.0
     steps:
+      - run: pacman -Syu --noconfirm
       - uses: actions/checkout@v3
       - run: rustup component add rustfmt
       - run: cargo fmt -- --check


### PR DESCRIPTION
Apparently the glibc is out of date, which makes it impossible to run node inside the container which is needed by the checkout action.