### PR TITLE
Use Rust 1.72.0 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   build_and_test:
     runs-on: ubuntu-22.04
-    container: rnestler/archlinux-rust:1.70.0
+    container: rnestler/archlinux-rust:1.72.0
     steps:
       - run: pacman -Syu --noconfirm
       - uses: actions/checkout@v3
@@ -28,7 +28,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-22.04
-    container: rnestler/archlinux-rust:1.70.0
+    container: rnestler/archlinux-rust:1.72.0
     steps:
       - run: pacman -Syu --noconfirm
       - uses: actions/checkout@v3
@@ -49,7 +49,7 @@ jobs:
 
   fmt:
     runs-on: ubuntu-22.04
-    container: rnestler/archlinux-rust:1.70.0
+    container: rnestler/archlinux-rust:1.72.0
     steps:
       - run: pacman -Syu --noconfirm
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cargo install reboot-arch-btw
 
 ## Build
 
-This project requires Rust 1.70.0 or newer. Also you need to have dbus
+This project requires Rust 1.72.0 or newer. Also you need to have dbus
 installed.
 
 ```Shell


### PR DESCRIPTION
This tool is for ArchLinux so we can always just use the latest stable Rust.