### PR TITLE
Print cleaned kernel version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+ * Print the cleaned kernel version
+   ([#160](https://github.com/rnestler/reboot-arch-btw/pull/160))
+
 ## [v0.5.7] - 2023-10-19
 
  * Update dependencies

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -104,7 +104,7 @@ impl Check for KernelChecker {
         println!("Kernel");
         println!(
             " installed: {} (since {})",
-            self.installed_kernel.version,
+            cleaned_kernel_version,
             self.installed_kernel.installed_reltime()
         );
         let running_kernel_version = &self.kernel_info.version;

--- a/src/package.rs
+++ b/src/package.rs
@@ -104,10 +104,11 @@ mod test {
     #[test]
     fn test_cleanup_pkg_version_missing_patch_digit() {
         assert_eq!(
-            PackageInfo::cleanup_kernel_version("5.16.arch1-1"),
-            Some("5.16.0.arch1.1".to_owned()),
+            PackageInfo::cleanup_kernel_version("6.7.arch3-1"),
+            Some("6.7.0.arch3.1".to_owned())
         );
     }
+
     #[test]
     fn test_read_number_none() {
         assert_eq!((None, "foo"), PackageInfo::read_number("foo"));


### PR DESCRIPTION
It confused me that it showed the following with kernel 6.7:

    Kernel
     installed: 6.7.arch3-1 (since 4 days ago)
     running:   6.7.0.arch3.1
    systemd updated 14 minutes ago
    Reboot arch btw

Note that we should reboot because of the systemd update, but since the
kernel versions look different I thought it was due to a bug in version
comparison.

Since we actually use a cleaned up version to compare the running kernel
we can also show it:

    Kernel
     installed: 6.7.0.arch3.1 (since 4 days ago)
     running:   6.7.0.arch3.1
    systemd updated 16 minutes ago
    Reboot arch btw

Makes it much clearer that the versions are the same. If we want to see
the raw versions before cleanup, we can enable INFO logging:

    [2024-01-20T17:07:35Z INFO  reboot_arch_btw::kernel] uname -r output: 6.7.0-arch3-1
    [2024-01-20T17:07:35Z INFO  reboot_arch_btw::kernel] Detected kernel package: linux
    [2024-01-20T17:07:35Z INFO  reboot_arch_btw::kernel] kernel package version: 6.7.arch3-1
    Kernel
     installed: 6.7.0.arch3.1 (since 4 days ago)
     running:   6.7.0.arch3.1
    [2024-01-20T17:07:35Z INFO  reboot_arch_btw::critical_packages_check] Checking systemd
    systemd updated 16 minutes ago
    Reboot arch btw