### PR TITLE
Run CI on PRs and master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push]
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
 
 env:
   RUSTUP_HOME: /root/.rustup


### PR DESCRIPTION
I noticed in https://github.com/rnestler/reboot-arch-btw/pull/169 that the CI didn't trigger.