### PR TITLE
Add verbose flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.2]
+
+ * Add verbose flag and make output more quite by default
+   ([#178](https://github.com/rnestler/reboot-arch-btw/pull/178))
+
 ## [v0.7.1] - 2024-03-17
 
  * Support libalpm v14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.7.2]
+## [Unreleased]
 
- * Add verbose flag and make output more quite by default
+ * Add `--verbose` flag and make output less verbose by default
    ([#178](https://github.com/rnestler/reboot-arch-btw/pull/178))
 
 ## [v0.7.1] - 2024-03-17

--- a/src/critical_packages_check.rs
+++ b/src/critical_packages_check.rs
@@ -10,6 +10,7 @@ pub struct CriticalPackagesCheck<'a> {
     restart_session_package_names: Vec<String>,
     session_info: SessionInfo,
     alpm_db: &'a alpm::Db,
+    verbose: bool,
 }
 
 impl CriticalPackagesCheck<'_> {
@@ -17,6 +18,7 @@ impl CriticalPackagesCheck<'_> {
         reboot_package_names: Vec<String>,
         restart_session_package_names: Vec<String>,
         alpm_db: &alpm::Db,
+        verbose: bool,
     ) -> Result<CriticalPackagesCheck> {
         let session_info = SessionInfo::from_utmp()?;
         Ok(CriticalPackagesCheck {
@@ -24,6 +26,7 @@ impl CriticalPackagesCheck<'_> {
             restart_session_package_names,
             session_info,
             alpm_db,
+            verbose,
         })
     }
 
@@ -37,10 +40,12 @@ impl CriticalPackagesCheck<'_> {
             }) = package_info
             {
                 if install_date > max_install_date {
-                    println!(
-                        "{package_name} updated {}",
-                        package_info.unwrap().installed_reltime()
-                    );
+                    if self.verbose {
+                        println!(
+                            "{package_name} updated {}",
+                            package_info.unwrap().installed_reltime()
+                        );
+                    }
                     return true;
                 }
             } else {

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -102,10 +102,11 @@ impl KernelInfo {
 pub struct KernelChecker {
     kernel_info: KernelInfo,
     installed_kernel: PackageInfo,
+    quiet: bool,
 }
 
 impl KernelChecker {
-    pub fn new(db: &alpm::Db) -> Result<KernelChecker> {
+    pub fn new(db: &alpm::Db, quiet: bool) -> Result<KernelChecker> {
         let kernel_info = KernelInfo::from_uname()?;
         let kernel_package = &kernel_info.package_name;
         info!("Detected kernel package: {kernel_package}");
@@ -115,6 +116,7 @@ impl KernelChecker {
         Ok(KernelChecker {
             kernel_info,
             installed_kernel,
+            quiet,
         })
     }
 }
@@ -124,15 +126,17 @@ impl Check for KernelChecker {
         let cleaned_kernel_version =
             PackageInfo::cleanup_kernel_version(&self.installed_kernel.version)
                 .expect("Could not clean version of installed kernel");
-        println!("Kernel");
-        println!(
-            " installed: {} (since {})",
-            cleaned_kernel_version,
-            self.installed_kernel.installed_reltime()
-        );
         let running_kernel_version = &self.kernel_info.version;
-        println!(" running:   {}", self.kernel_info);
         let should_reboot = running_kernel_version != &cleaned_kernel_version;
+        if !self.quiet || should_reboot {
+            println!("Kernel");
+            println!(
+                " installed: {} (since {})",
+                cleaned_kernel_version,
+                self.installed_kernel.installed_reltime()
+            );
+            println!(" running:   {}", self.kernel_info);
+        }
         if should_reboot {
             CheckResult::KernelUpdate
         } else {
@@ -230,6 +234,7 @@ mod test {
                 version: "5.19.11.arch1-1".to_owned(),
                 install_date: None,
             },
+            quiet: false,
         };
 
         assert_eq!(kernel_checker.check(), CheckResult::KernelUpdate);
@@ -243,6 +248,7 @@ mod test {
                 version: "5.19.9.arch1-1".to_owned(),
                 install_date: None,
             },
+            quiet: false,
         };
 
         assert_eq!(kernel_checker.check(), CheckResult::Nothing);

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -102,11 +102,11 @@ impl KernelInfo {
 pub struct KernelChecker {
     kernel_info: KernelInfo,
     installed_kernel: PackageInfo,
-    quiet: bool,
+    verbose: bool,
 }
 
 impl KernelChecker {
-    pub fn new(db: &alpm::Db, quiet: bool) -> Result<KernelChecker> {
+    pub fn new(db: &alpm::Db, verbose: bool) -> Result<KernelChecker> {
         let kernel_info = KernelInfo::from_uname()?;
         let kernel_package = &kernel_info.package_name;
         info!("Detected kernel package: {kernel_package}");
@@ -116,7 +116,7 @@ impl KernelChecker {
         Ok(KernelChecker {
             kernel_info,
             installed_kernel,
-            quiet,
+            verbose,
         })
     }
 }
@@ -128,7 +128,7 @@ impl Check for KernelChecker {
                 .expect("Could not clean version of installed kernel");
         let running_kernel_version = &self.kernel_info.version;
         let should_reboot = running_kernel_version != &cleaned_kernel_version;
-        if !self.quiet || should_reboot {
+        if self.verbose {
             println!("Kernel");
             println!(
                 " installed: {} (since {})",
@@ -234,7 +234,7 @@ mod test {
                 version: "5.19.11.arch1-1".to_owned(),
                 install_date: None,
             },
-            quiet: false,
+            verbose: false,
         };
 
         assert_eq!(kernel_checker.check(), CheckResult::KernelUpdate);
@@ -248,7 +248,7 @@ mod test {
                 version: "5.19.9.arch1-1".to_owned(),
                 install_date: None,
             },
-            quiet: false,
+            verbose: false,
         };
 
         assert_eq!(kernel_checker.check(), CheckResult::Nothing);

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,10 @@ struct Args {
         default_value = "xorg-server,xorg-xwayland"
     )]
     session_restart_packages: Vec<String>,
+
+    // Don't print kernel info to terminal if kernel is up to date
+    #[clap(short, long)]
+    quiet: bool,
 }
 
 fn main() {
@@ -61,7 +65,7 @@ fn main() {
 
     let mut checkers: Vec<Box<dyn Check>> = vec![];
 
-    match KernelChecker::new(db) {
+    match KernelChecker::new(db, args.quiet) {
         Ok(kernel_checker) => checkers.push(Box::new(kernel_checker)),
         Err(err) => {
             error!("Could not create kernel checker: {err:#}")

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ struct Args {
     )]
     session_restart_packages: Vec<String>,
 
-    // Print kernel version info.
+    /// Always print kernel version info and show updated packages.
     #[clap(short, long)]
     verbose: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,9 +49,9 @@ struct Args {
     )]
     session_restart_packages: Vec<String>,
 
-    // Don't print kernel info to terminal if kernel is up to date
+    // Print kernel version info.
     #[clap(short, long)]
-    quiet: bool,
+    verbose: bool,
 }
 
 fn main() {
@@ -65,14 +65,19 @@ fn main() {
 
     let mut checkers: Vec<Box<dyn Check>> = vec![];
 
-    match KernelChecker::new(db, args.quiet) {
+    match KernelChecker::new(db, args.verbose) {
         Ok(kernel_checker) => checkers.push(Box::new(kernel_checker)),
         Err(err) => {
             error!("Could not create kernel checker: {err:#}")
         }
     }
 
-    match CriticalPackagesCheck::new(args.reboot_packages, args.session_restart_packages, db) {
+    match CriticalPackagesCheck::new(
+        args.reboot_packages,
+        args.session_restart_packages,
+        db,
+        args.verbose,
+    ) {
         Ok(critical_packages_checker) => checkers.push(Box::new(critical_packages_checker)),
         Err(err) => {
             error!("Could not create critical package checker: {err:#}")

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ struct Args {
     )]
     session_restart_packages: Vec<String>,
 
-    /// Always print kernel version info and show updated packages.
+    /// Print kernel version info and show updated packages.
     #[clap(short, long)]
     verbose: bool,
 }


### PR DESCRIPTION
Add a `-v`/`--verbose` flag so that kernel version isn't printed every time pacman updates or for MOTD. 