### PR TITLE
Use Rust 1.80.1 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build_and_test:
     runs-on: ubuntu-22.04
-    container: rnestler/archlinux-rust:1.78.0
+    container: rnestler/archlinux-rust:1.80.1
     steps:
       - run: pacman -Syu --noconfirm
       - uses: actions/checkout@v3
@@ -32,7 +32,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-22.04
-    container: rnestler/archlinux-rust:1.78.0
+    container: rnestler/archlinux-rust:1.80.1
     steps:
       - run: pacman -Syu --noconfirm
       - uses: actions/checkout@v3
@@ -53,7 +53,7 @@ jobs:
 
   fmt:
     runs-on: ubuntu-22.04
-    container: rnestler/archlinux-rust:1.78.0
+    container: rnestler/archlinux-rust:1.80.1
     steps:
       - run: pacman -Syu --noconfirm
       - uses: actions/checkout@v3


### PR DESCRIPTION
We will need an up to date Docker container when pacman 7 hits the core repositories. See also #187.