### PR TITLE
Switch to gumdrop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,44 +123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
-name = "clap"
-version = "4.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
-dependencies = [
- "anstyle",
- "clap_lex",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,10 +213,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.5.0"
+name = "gumdrop"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+checksum = "5bc700f989d2f6f0248546222d9b4258f5b02a171a431f8285a81c08142629e3"
+dependencies = [
+ "gumdrop_derive",
+]
+
+[[package]]
+name = "gumdrop_derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729f9bd3449d77e7831a18abfb7ba2f99ee813dfd15b8c2167c9a54ba20aa99d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -283,7 +259,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -461,8 +437,8 @@ version = "0.9.0"
 dependencies = [
  "alpm",
  "anyhow",
- "clap",
  "env_logger",
+ "gumdrop",
  "log",
  "notify-rust",
  "time",
@@ -515,7 +491,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -523,6 +499,17 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -573,7 +560,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -584,7 +571,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -718,7 +705,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -729,7 +716,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -875,5 +862,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2024"
 
 [dependencies]
 alpm = "4.0.3"
-clap = { version = "4.5.39", features = ["help", "usage", "error-context", "std", "derive"], default-features = false }
+gumdrop = { version = "0.8", features = ["default_expr"] }
 notify-rust = { version = "4.11", features = ["d"], default-features = false }
 utmp-rs = "0.4.0"
 time = "0.3.41"


### PR DESCRIPTION
This was to try to reduce the binary size. Results of this PR:

 * Binary size reduced to 1.8M from 2.2M
 * No `--version` support
 * No multiline helptext (https://github.com/murarth/gumdrop/issues/42)
 * No about text
 
 So I'm not sure if this is worth the trade-off.
 
 Old help output:
 ```
 reboot-arch-btw --help
Check if a reboot is needed due to an updated kernel or other system packages.

Usage: reboot-arch-btw [OPTIONS]

Options:
      --disable-notification
          Disable desktop notification

      --notification-timeout <NOTIFICATION_TIMEOUT>
          Timeout for the desktop notification in milliseconds.

          * "default" will leave the timeout to be set by the server.

          * "never" or "0" will cause the notification never to expire.

          * Any other number will be interpreted as the timeout in milliseconds.

          [default: default]

      --reboot-packages <REBOOT_PACKAGES>
          Comma separated list of packages were we should reboot after an upgrade

          [default: systemd,linux-firmware,amd-ucode,intel-ucode]

      --session-restart-packages <SESSION_RESTART_PACKAGES>
          Comma separated list of packages were we should restart our session after an upgrade

          [default: xorg-server,xorg-xwayland]

  -v, --verbose
          Print kernel version info and show updated packages

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```

New help output
```
Usage: target/debug/reboot-arch-btw [OPTIONS]

Optional arguments:
  -h, --help
  --disable-notification  Disable desktop notification
  --notification-timeout NOTIFICATION-TIMEOUT
                          Timeout for the desktop notification in milliseconds. (default: default)
  --reboot-packages REBOOT-PACKAGES
                          Comma separated list of packages were we should reboot after an upgrade. (default: systemd,linux-firmware,amd-ucode,intel-ucode)
  --session-restart-packages SESSION-RESTART-PACKAGES
                          Comma separated list of packages were we should restart our session after an upgrade. (default: xorg-server,xorg-xwayland)
  -v, --verbose           Print kernel version info and show updated packages.
r
```