### PR TITLE
Fix documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ indicating that you probably want to reboot your system.
 If no restart is needed, `reboot-arch-btw` won't output anything by default.
 Use `--verbose` to always get some output.
 
-One can use `--reboot-packages` or `--reboot-packages` to set the list of
-packages which should also trigger a notification if they are updated.
+One can use `--reboot-packages` or `--session-restart-packages` to set the list
+of packages which should also trigger a notification if they are updated.
 
 ```
 $ reboot-arch-btw --help

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ struct Args {
     #[clap(long, default_value = "default")]
     notification_timeout: Timeout,
 
-    /// Comma separated list of packages were we should reboot after an upgrade.
+    /// Comma separated list of packages where we should reboot after an upgrade.
     #[clap(
         long,
         use_value_delimiter = true,
@@ -41,7 +41,7 @@ struct Args {
     )]
     reboot_packages: Vec<String>,
 
-    /// Comma separated list of packages were we should restart our session after an upgrade.
+    /// Comma separated list of packages where we should restart our session after an upgrade.
     #[clap(
         long,
         use_value_delimiter = true,


### PR DESCRIPTION
- README: second flag in the packages hint was duplicated (--reboot-packages listed twice); fix to --session-restart-packages
- --help text: "packages were we should" -> "where we should"