### PR TITLE
Clamp installed_reltime delta to avoid overflow on future install dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+ * Fix wrong "install time ago" output when a package's install date is in the
+   future (e.g. due to clock skew)
+
 ## [v1.0.0] - 2026-03-09
 
  * Reduce binary size by disabling regex and color support for log messages

--- a/src/package.rs
+++ b/src/package.rs
@@ -125,4 +125,19 @@ mod test {
     fn test_read_number() {
         assert_eq!((Some(1), ".1-foo"), PackageInfo::read_number("1.1-foo"));
     }
+
+    #[test]
+    fn test_installed_reltime_future_install_date() {
+        // A package with an install date in the future (e.g. clock skew) must
+        // not wrap into a garbage value but clamp to "0 seconds ago".
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let package = PackageInfo {
+            version: "1.0.0-1".to_owned(),
+            install_date: Some((now + 3600) as i64),
+        };
+        assert_eq!(package.installed_reltime(), "0 seconds ago");
+    }
 }

--- a/src/package.rs
+++ b/src/package.rs
@@ -63,7 +63,9 @@ impl PackageInfo {
             .duration_since(UNIX_EPOCH)
             .expect("Time went backwards!")
             .as_secs();
-        let delta = now - install_date;
+        // Clamp to 0 if the install date is in the future (e.g. clock skew) to
+        // avoid wrapping into a garbage value (overflow checks are off in release).
+        let delta = now.saturating_sub(install_date);
         if delta < 60 {
             format!("{} seconds ago", delta)
         } else if delta < 7200 {


### PR DESCRIPTION
If a package's install date is in the future (e.g. clock skew), the `now - install_date` subtraction wrapped into a garbage value in release builds (overflow checks are off there). Use saturating_sub so we show "0 seconds ago" instead.