### PR TITLE
Read utmp from /run/utmp instead of legacy /var/run/utmp

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -10,7 +10,7 @@ pub struct SessionInfo {
 
 impl SessionInfo {
     pub fn from_utmp() -> Result<SessionInfo> {
-        let entries = utmp_rs::parse_from_path("/var/run/utmp")
+        let entries = utmp_rs::parse_from_path("/run/utmp")
             .with_context(|| anyhow!("Could not read utmp"))?;
         Self::from_utmp_entries(&entries)
     }


### PR DESCRIPTION
/var/run is a compatibility symlink to /run on modern systems; use the canonical path directly.