### PR TITLE
Show all updated critical packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
  * Update minimum supported Rust version to 1.97.0
+ * In verbose mode, list all updated reboot/session-restart packages instead of
+   only the first one
 
 ## [v1.0.1] - 2026-07-10
 

--- a/src/critical_packages_check.rs
+++ b/src/critical_packages_check.rs
@@ -31,6 +31,7 @@ impl CriticalPackagesCheck<'_> {
     }
 
     fn check_package_list(&self, package_list: &[String], max_install_date: i64) -> bool {
+        let mut any_updated = false;
         for package_name in package_list {
             info!("Checking {package_name}");
             match get_package_version(self.alpm_db, package_name) {
@@ -47,13 +48,13 @@ impl CriticalPackagesCheck<'_> {
                                 package_info.installed_reltime()
                             );
                         }
-                        return true;
+                        any_updated = true;
                     }
                 }
                 _ => warn!("Failed to get package info for {package_name}"),
             }
         }
-        false
+        any_updated
     }
 }
 
@@ -62,10 +63,14 @@ impl Check for CriticalPackagesCheck<'_> {
         let boot_time = self.session_info.boot_time.unix_timestamp();
         let session_time = self.session_info.session_time.unix_timestamp();
 
-        if self.check_package_list(&self.reboot_package_names, boot_time) {
+        let reboot_needed = self.check_package_list(&self.reboot_package_names, boot_time);
+        let session_needed =
+            self.check_package_list(&self.restart_session_package_names, session_time);
+
+        if reboot_needed {
             return CheckResult::Reboot;
         }
-        if self.check_package_list(&self.restart_session_package_names, session_time) {
+        if session_needed {
             return CheckResult::RestartSession;
         }
         CheckResult::Nothing


### PR DESCRIPTION
Previously the checks would early return and thus only show the first package.

So it would show something like

     systemd updated 4 minutes ago
     linux-firmware updated 4 minutes ago
     intel-ucode updated 4 minutes ago
     Reboot arch btw

Instead of just

     systemd updated 4 minutes ago
     Reboot arch btw