### PR TITLE
Add --exit-code flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Update minimum supported Rust version to 1.97.0
  * In verbose mode, list all updated reboot/session-restart packages instead of
    only the first one
+ * Add `--exit-code` flag to return a non-zero exit code based on the check
+   result: 0 = nothing to do, 1 = reboot needed, 2 = session restart needed.
+   Unexpected errors (e.g. failure to open the pacman database) will panic and
+   result in exit code 101 regardless of this flag.
 
 ## [v1.0.1] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    only the first one
  * Add `--exit-code` flag to return a non-zero exit code based on the check
    result: 0 = nothing to do, 1 = reboot needed, 2 = session restart needed.
-   Unexpected errors (e.g. failure to open the pacman database) will panic and
-   result in exit code 101 regardless of this flag.
+   Regardless of this flag, unexpected errors (e.g. failure to open the pacman
+   database) will panic and exit with code 101, while invalid command line
+   arguments will exit with code 64.
 
 ## [v1.0.1] - 2026-07-10
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+
 use log::error;
 use notify_rust::{Notification, Timeout};
 
@@ -52,6 +53,15 @@ struct Args {
     /// Print kernel version info and show updated packages.
     #[clap(short, long)]
     verbose: bool,
+
+    /// Return a non-zero exit code based on the check result:
+    ///   0 = nothing to do
+    ///   1 = reboot needed
+    ///   2 = session restart needed
+    /// Unexpected errors (e.g. failure to open the pacman database) will
+    /// panic and result in exit code 101 regardless of this flag.
+    #[clap(long)]
+    exit_code: bool,
 }
 
 fn main() {
@@ -101,5 +111,14 @@ fn main() {
                 .map_err(|e| error!("Couldn't send notification: {}", e))
                 .ok();
         }
+    }
+
+    if args.exit_code {
+        let code = match result {
+            CheckResult::Nothing => 0,
+            CheckResult::Reboot | CheckResult::KernelUpdate => 1,
+            CheckResult::RestartSession => 2,
+        };
+        std::process::exit(code);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,15 +58,22 @@ struct Args {
     ///   0 = nothing to do
     ///   1 = reboot needed
     ///   2 = session restart needed
-    /// Unexpected errors (e.g. failure to open the pacman database) will
-    /// panic and result in exit code 101 regardless of this flag.
+    /// Regardless of this flag, unexpected errors (e.g. failure to open the
+    /// pacman database) will panic and exit with code 101, while invalid
+    /// command line arguments will exit with code 64.
     #[clap(long)]
     exit_code: bool,
 }
 
 fn main() {
     env_logger::init();
-    let args = Args::parse();
+    let args = match Args::try_parse() {
+        Ok(args) => args,
+        Err(e) => {
+            let _ = e.print();
+            std::process::exit(64);
+        }
+    };
 
     // Initialize Pacman database
     let alpm = alpm::Alpm::new("/", "/var/lib/pacman/")


### PR DESCRIPTION
Return a non-zero exit code based on the check result:
  0 = nothing to do
  1 = reboot needed
  2 = session restart needed
Unexpected errors (e.g. failure to open the pacman database) will panic and result in exit code 101 regardless of this flag.